### PR TITLE
Optimize sonic-db-cli dict type output to JSON format

### DIFF
--- a/src/swsssdk/scripts/sonic-db-cli
+++ b/src/swsssdk/scripts/sonic-db-cli
@@ -4,6 +4,7 @@ import sys
 import swsssdk
 import redis
 import argparse
+import json
 from multiprocessing import Pool
 from functools import partial
 
@@ -80,6 +81,8 @@ def execute_cmd(dbname, cmd, namespace, use_unix_socket=False):
             print()
         elif isinstance(resp, list):
             print("\n".join(resp))
+        elif isinstance(resp, dict):
+            print(json.dumps(resp))
         else:
             print(resp)
         sys.exit(0)


### PR DESCRIPTION
Why I did this?

Optimize sonic-db-cli to fix issue https://github.com/Azure/sonic-py-swsssdk/issues/100. 

Sometimes, sonic-mgmt need check values in redis db by calling "sonic-db-cli $DB HGETALL $KEY". And it would be great if the output of such command can be parsed to a python dictionary easily. 

However, sonic-db-cli now return raw string for hgetall comamnd. For example:

```
admin@r-leopard-01:~$ sonic-db-cli CONFIG_DB HGETALL "TELEMETRY|gnmi"
{'client_auth': 'false', 'log_level': '2', 'port': '50051'}
```

Python json module cannot parse such string to a dictionary:
```
{'client_auth': 'false', 'log_level': '2', 'port': '50051'}
```

How I did this?

```python
        if resp is None:
            print()
        elif isinstance(resp, list):
            print("\n".join(resp))
        else:
            print(resp)
```

to 

```python
        if resp is None:
            print()
        elif isinstance(resp, list):
            print("\n".join(resp))
        elif isinstance(resp, dict):
            json.dumps(resp)
        else:
            print(resp)
```

How I verify this?

Manual test.
